### PR TITLE
added import line to api_key.py

### DIFF
--- a/official-ws/python/util/api_key.py
+++ b/official-ws/python/util/api_key.py
@@ -1,3 +1,4 @@
+import time, urlparse, hmac, hashlib
 def generate_nonce():
     return int(round(time.time() * 1000))
 


### PR DESCRIPTION
Some imports were needed to make the python WS connector work. Please ignore if not needed.