### PR TITLE
Make sure reconnect listener is added on every open

### DIFF
--- a/official-ws/nodejs/lib/createSocket.js
+++ b/official-ws/nodejs/lib/createSocket.js
@@ -17,6 +17,12 @@ module.exports = function createSocket(options, bmexClient) {
     wsClient.opened = true;
     debug('Connection to BitMEX at', wsClient.url, 'opened.');
     bmexClient.emit('open');
+
+    // Have to regenerate endpoint on reconnection so we have a new nonce.
+    wsClient.addListener('reconnect', function() {
+      wsClient.url = makeEndpoint(options);
+      debug('Reconnecting to BitMEX at ', wsClient.url);
+    });
   };
 
   wsClient.onclose = function() {
@@ -67,12 +73,6 @@ module.exports = function createSocket(options, bmexClient) {
   };
 
   wsClient.open(endpoint);
-
-  // Have to regenerate endpoint on reconnection so we have a new nonce.
-  wsClient.addListener('reconnect', function() {
-    wsClient.url = makeEndpoint(options);
-    debug('Reconnecting to BitMEX at ', wsClient.url);
-  });
 
   return wsClient;
 };


### PR DESCRIPTION
If the websocket is disconnected, a close event will be emitted on the websocket, by the following code in ws:

![billede](https://user-images.githubusercontent.com/10992982/34272378-5fa48386-e690-11e7-8444-a0f531cf7122.png)

This removes all listeners from the websocket, including the reconnect listener which is supposed to refresh the authentication with a new nonce, if the connection is authenticated.

If the connection is lost a second time, the endpoint will no longer be refreshed and the previous nonce will be reused. The server will refuse the connection attempt because of nonce reuse, causing the client to throw an exception and end.

This patch moves the reconnection event listener code to be added in the onopen() function, so the listener gets reattached when the connection is reopened.