### PR TITLE
Add node-fetch REST example

### DIFF
--- a/official-http/node-fetch/README.md
+++ b/official-http/node-fetch/README.md
@@ -1,0 +1,17 @@
+# Authenticated requests with `node-fetch`
+
+This example implements a `makeRequest()` method that uses the lightweight
+[node-fetch](https://github.com/bitinn/node-fetch) module to sign and make
+a request to the BitMEX REST API.
+
+
+# Usage
+
+Supply the `apiKey` and `apiSecret`, then run:
+
+```sh
+npm install
+node index
+```
+
+The example will dump information about your current position(s).

--- a/official-http/node-fetch/index.js
+++ b/official-http/node-fetch/index.js
@@ -1,0 +1,62 @@
+const fetch = require('node-fetch');
+const crypto = require('crypto');
+
+const apiKey = 'API_KEY';
+const apiSecret = 'API_SECRET';
+
+function makeRequest(verb, endpoint, data = {}) {
+  const apiRoot = '/api/v1/';
+
+  const expires = new Date().getTime() + (60 * 1000);  // 1 min in the future
+
+  let query = '', postBody = '';
+  if (verb === 'GET')
+    query = '?' + Object.entries(data).map(
+      ([key, value]) => key + '=' + encodeURIComponent(value instanceof Object ? JSON.stringify(value) : value)
+    ).join('&');
+  else
+    // Pre-compute the reqBody so we can be sure that we're using *exactly* the same body in the request
+    // and in the signature. If you don't do this, you might get differently-sorted keys and blow the signature.
+    postBody = JSON.stringify(data);
+
+  const signature = crypto.createHmac('sha256', apiSecret)
+    .update(verb + apiRoot + endpoint + query + expires + postBody).digest('hex');
+
+  const headers = {
+    'content-type': 'application/json',
+    'accept': 'application/json',
+    // This example uses the 'expires' scheme. You can also use the 'nonce' scheme. See
+    // https://www.bitmex.com/app/apiKeysUsage for more details.
+    'api-expires': expires,
+    'api-key': apiKey,
+    'api-signature': signature,
+  };
+
+  const requestOptions = {
+    method: verb,
+    headers,
+  };
+  if (verb !== 'GET') requestOptions.body = postBody;  // GET/HEAD requests can't have body
+
+  const url = 'https://www.bitmex.com' + apiRoot + endpoint + query;
+
+  return fetch(url, requestOptions).then(response => response.json()).then(
+    response => {
+      if ('error' in response) throw new Error(response.error.message);
+      return response;
+    },
+    error => console.error('Network error', error),
+  );
+}
+
+(async function main() {
+  try {
+    const result = await makeRequest('GET', 'position', {
+      filter: { symbol: 'XBTUSD' },
+      columns: ['currentQty', 'avgEntryPrice'],
+    });
+    console.log(result);
+  } catch (e) {
+    console.error(e);
+  };
+}());

--- a/official-http/node-fetch/index.js
+++ b/official-http/node-fetch/index.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const crypto = require('crypto');
+const qs = require('qs');
 
 const apiKey = 'API_KEY';
 const apiSecret = 'API_SECRET';
@@ -11,9 +12,7 @@ function makeRequest(verb, endpoint, data = {}) {
 
   let query = '', postBody = '';
   if (verb === 'GET')
-    query = '?' + Object.entries(data).map(
-      ([key, value]) => key + '=' + encodeURIComponent(value instanceof Object ? JSON.stringify(value) : value)
-    ).join('&');
+    query = '?' + qs.stringify(data);
   else
     // Pre-compute the reqBody so we can be sure that we're using *exactly* the same body in the request
     // and in the signature. If you don't do this, you might get differently-sorted keys and blow the signature.

--- a/official-http/node-fetch/package.json
+++ b/official-http/node-fetch/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bitmex-node-fetch",
+  "version": "0.0.1-unreleased",
+  "description": "An example of using node-fetch for BitMEX API authentication",
+  "main": "index.js",
+  "private": true,
+  "author": "https://github.com/bomper",
+  "license": "MIT",
+  "homepage": "https://github.com/BitMEX/api-connectors/tree/master/official-http/node-fetch",
+  "dependencies": {
+    "node-fetch": "latest"
+  }
+}


### PR DESCRIPTION
Doesn't go as far as [not having any external dependencies](https://www.tomas-dvorak.cz/posts/nodejs-request-without-dependencies/), but `node-fetch` is much lighter than `request`.

`node-fetch` can also easily be replaced with [cross-fetch](https://github.com/lquixada/cross-fetch) for the browser, though this probably won't work due to the [lack of CORS headers](https://github.com/BitMEX/api-connectors/issues/52#issuecomment-353606491).