### PR TITLE
Do not emit split data for no-symbol tables

### DIFF
--- a/official-ws/nodejs/lib/createSocket.js
+++ b/official-ws/nodejs/lib/createSocket.js
@@ -42,19 +42,18 @@ module.exports = function createSocket(options, bmexClient) {
     if (data.error) return bmexClient.emit('error', data.error);
     if (!data.data) return; // connection or subscription notice
 
-
-    // Fires events as <table>:<action>:<symbol>, such as
-    // instrument:update:XBTUSD.
-    // Consumers may be listening on:
-    // * action filter   (e.g. `instrument:partial:*`)
-    // * symbol filter   (e.g. `instrument:*:XBTUSD`)
-    // * table filter    (e.g. `instrument:*:*`)
-    emitSplitData(bmexClient, data);
-
-    // For no-symbol tables, emit a '*' event.
     const tableNoSymbol = _.includes(bmexClient.constructor.noSymbolTables, data.table);
     if (tableNoSymbol) {
+      // For no-symbol tables, emit a '*' event.
       emitFullData(bmexClient, data);
+    } else {
+      // Fires events as <table>:<action>:<symbol>, such as
+      // instrument:update:XBTUSD.
+      // Consumers may be listening on:
+      // * action filter   (e.g. `instrument:partial:*`)
+      // * symbol filter   (e.g. `instrument:*:XBTUSD`)
+      // * table filter    (e.g. `instrument:*:*`)
+      emitSplitData(bmexClient, data);
     }
   };
 


### PR DESCRIPTION
The present code will call both emitSplitData and emitFullData for no-symbol tables. The result of this is that whenever a message arrives on a no-symbol table, two messages will be emitted, one of which will be an empty array.

I may be missing something, but I don't think this behaviour is desirable. At least for me I just want the data when it's updated.

So this PR changes the behaviour to either use emitSplitData or emitFullData, for symbol and no-symbol tables respectively.
