### PR TITLE
Fix for issue #120

### DIFF
--- a/official-ws/nodejs/lib/createSocket.js
+++ b/official-ws/nodejs/lib/createSocket.js
@@ -82,15 +82,15 @@ function emitSplitData(emitter, data) {
   // Technically, we can change this (e.g. chat channels)
   const filterKey = data.filterKey || 'symbol';
 
-  // By looking at what we're subscribed to, we can save time by only emitting those events.
-  const matchingStreams = emitter._listenerTree[table];
-  const symbolData = _.mapValues(matchingStreams, () => []);
-
-  // This is similar to _groupBy, but faster.
-  for (let i = 0; i < data.data.length; i++) {
-    const d = data.data[i];
-    if (symbolData[d[filterKey]]) symbolData[d[filterKey]].push(d);
-  }
+  // Generate data by symbol
+  const symbolData = data.data.reduce((accumulator, currentValue) => {
+    if (accumulator.hasOwnProperty(currentValue[filterKey])) {
+      accumulator[currentValue[filterKey]].push(currentValue);
+    } else {
+      accumulator[currentValue[filterKey]] = [currentValue];
+    }
+    return accumulator;
+  }, {});
 
   Object.keys(symbolData).forEach((symbol) => {
     const key = `${table}:${action}:${symbol}`;


### PR DESCRIPTION
This fixes issue #120.

It removes the dependency on `_listenerTree` for figuring out who to send to. Instead in checks the actual data recieved and sends to listeners for that data.

This lays the foundation for support for `"*"` symbol subscriptions as well. This could be added in line 93 by changing the empty object to `{ '*': data.data }`. This is not included in this patch, because it would cause more breakage, since other parts of the library doesn't expect it.