### PR TITLE
Remove dash in definition key to avoid swagger-codegen to generate wrong code

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4223,7 +4223,7 @@
       ],
       "type": "object"
     },
-    "x-any": {
+    "foo": {
       "properties": {},
       "type": "object"
     },
@@ -4255,7 +4255,7 @@
           "default": [],
           "type": "array",
           "items": {
-            "$ref": "#/definitions/x-any"
+            "$ref": "#/definitions/foo"
           }
         },
         "enabled": {


### PR DESCRIPTION
As an example, when you use the **cpprest** generator, it generates a class named `X-any` which is an invalid name for a class in C++.

It happens because swagger-codegen doesn't take into account this _hurting_ character. See [this issue](https://github.com/swagger-api/swagger-codegen/issues/8460) for more information.