### PR TITLE
Correcting logical operators precedence

### DIFF
--- a/official-ws/python/bitmex_websocket.py
+++ b/official-ws/python/bitmex_websocket.py
@@ -122,7 +122,7 @@ class BitMEXWebsocket:
 
         # Wait for connect before continuing
         conn_timeout = 5
-        while not self.ws.sock or not self.ws.sock.connected and conn_timeout:
+        while (not self.ws.sock or not self.ws.sock.connected) and conn_timeout:
             sleep(1)
             conn_timeout -= 1
         if not conn_timeout:


### PR DESCRIPTION
The precedence of the logical operators is not correct. I have tested this.

Thank you.