### PR TITLE
node.js: Empty orders subscription result when no order on websocket connection startup

### DIFF
--- a/official-ws/nodejs/lib/deltaParser.js
+++ b/official-ws/nodejs/lib/deltaParser.js
@@ -33,6 +33,16 @@ module.exports = {
    * @return {Array}            Updated data.
    */
   onAction(action, tableName, symbol, client, data) {
+    // temp fix for new orders when none existed previously
+    if (
+        tableName === "order" &&
+        action === "insert" &&
+        !isInitialized(tableName, symbol, client)
+    ) {
+        data.keys = ["orderID"];
+        return this._partial(tableName, symbol, client, data);
+    }
+    
     // Deltas before the getSymbol() call returns can be safely discarded.
     if (action !== 'partial' && !isInitialized(tableName, symbol, client)) return [];
     // Partials initialize the table, so there's a different signature.


### PR DESCRIPTION
When you connect via websocket the order subscription callback everytime provides an empty array. Is because the `insert` action does not the interal storage and so on no data will be saved.
The problem does not exists if you have an order on startup, then the internal storage is create an orders are updated

see #259 #210 #203 #166

Patch from: https://github.com/BitMEX/api-connectors/issues/166#issuecomment-404088343



Expected
 * connect via websocket
 * no open orders
 * create a new order
 * order via insert is provided in `client.addStream('*', 'position', (positions) => {))` callback