### PR TITLE
[node-http] calc expiry date as second based timestamp

### DIFF
--- a/official-http/node-fetch/index.js
+++ b/official-http/node-fetch/index.js
@@ -8,7 +8,7 @@ const apiSecret = 'API_SECRET';
 function makeRequest(verb, endpoint, data = {}) {
   const apiRoot = '/api/v1/';
 
-  const expires = new Date().getTime() + (60 * 1000);  // 1 min in the future
+  const expires = Math.round(new Date().getTime() / 1000) + 60; // 1 min in the future
 
   let query = '', postBody = '';
   if (verb === 'GET')

--- a/official-http/node-request/index.js
+++ b/official-http/node-request/index.js
@@ -6,7 +6,7 @@ var apiSecret = "API_SECRET";
 
 var verb = 'POST',
   path = '/api/v1/order',
-  expires = new Date().getTime() + (60 * 1000), // 1 min in the future
+  expires = Math.round(new Date().getTime() / 1000) + 60, // 1 min in the future
   data = {symbol:"XBTUSD",orderQty:1,price:590,ordType:"Limit"};
 
 // Pre-compute the postBody so we can be sure that we're using *exactly* the same body in the request


### PR DESCRIPTION
The [API docs](https://www.bitmex.com/app/apiKeysUsage#Authenticating-with-an-API-Key) say:

> UNIX timestamps are in seconds. For example, 2018-02-08T04:30:37Z is `1518064237`. 

However the current nodejs example scripts generates and passes millisecond based timestamps, which can be replayed if captured for a very long time, until at least the year 51004.

This PR fixes the 2 nodejs examples.