### PR TITLE
Don't append but replace data on partial message

### DIFF
--- a/official-ws/python/bitmex_websocket.py
+++ b/official-ws/python/bitmex_websocket.py
@@ -207,7 +207,7 @@ class BitMEXWebsocket:
                 # 'delete'  - delete row
                 if action == 'partial':
                     self.logger.debug("%s: partial" % table)
-                    self.data[table] += message['data']
+                    self.data[table] = message['data']
                     # Keys are communicated on partials to let you know how to uniquely identify
                     # an item. We use it for updates.
                     self.keys[table] = message['keys']


### PR DESCRIPTION
From https://www.bitmex.com/app/wsAPI
```
  // 'partial'; This is a table image, replace your data entirely.
```
therefore replace the data entirely, not append.