### PR TITLE
Python: correct websocket timeout condition

### DIFF
--- a/official-ws/python/bitmex_websocket.py
+++ b/official-ws/python/bitmex_websocket.py
@@ -126,7 +126,7 @@ class BitMEXWebsocket:
 
         # Wait for connect before continuing
         conn_timeout = 5
-        while not self.ws.sock or not self.ws.sock.connected and conn_timeout:
+        while (not self.ws.sock or not self.ws.sock.connected) and conn_timeout:
             sleep(1)
             conn_timeout -= 1
         if not conn_timeout:


### PR DESCRIPTION
The websocket __connect() would never time out, as `not self.ws.sock`
always evaluates to True after initiating a connect. Fixed with proper
use of parenthesis.