### PR TITLE
Fix bug in signature generation.

### DIFF
--- a/official-http/csharp/BitMEXAPI.cs
+++ b/official-http/csharp/BitMEXAPI.cs
@@ -84,7 +84,7 @@ namespace BitMEX
             if (auth)
             {
                 string expires = GetExpires().ToString();
-                string message = method + url + expires + postData;
+                string message = method + "/api/v1" + function + expires + postData;
                 byte[] signatureBytes = hmacsha256(Encoding.UTF8.GetBytes(apiSecret), Encoding.UTF8.GetBytes(message));
                 string signatureString = ByteArrayToString(signatureBytes);
 


### PR DESCRIPTION
This fixes a bug in the wrapper where the whole GET query was signed, but bitMEX want only the path and function to be signed. Fixes #356 .