### PR TITLE
add ignore pong response to socketClient

### DIFF
--- a/official-ws/nodejs/README.md
+++ b/official-ws/nodejs/README.md
@@ -133,3 +133,13 @@ DEBUG=* node example.js
 # Display all high-level debug messages
 DEBUG=BitMEX:* node example.js
 ```
+
+### Heartbeat
+https://www.bitmex.com/app/wsAPI#Heartbeats
+
+you can implement a more thorough solution, but hope this helps along
+```
+setInterval(() => {
+  client.socket.send("ping")
+}, 30 * 1000); // sends ping every 30 s
+```

--- a/official-ws/nodejs/lib/createSocket.js
+++ b/official-ws/nodejs/lib/createSocket.js
@@ -33,6 +33,9 @@ module.exports = function createSocket(options, bmexClient) {
 
   wsClient.onmessage = function(data) {
     try {
+      if (data === "pong") {
+        return;
+      }
       data = JSON.parse(data);
       debug('Received %j', data);
     } catch(e) {


### PR DESCRIPTION
Add a code sample how to expose and a very basic ping sending.
Add a ignore clause to webSocketClient.on('message') if the payload is === 'pong'