### PR TITLE
liquidation subscription doesn't take a symbol

### DIFF
--- a/official-ws/python/util/subscriptions.py
+++ b/official-ws/python/util/subscriptions.py
@@ -10,7 +10,8 @@ NO_SYMBOL_SUBS = [
     "publicNotifications",
     "privateNotifications",
     "transact",
-    "wallet"
+    "wallet",
+    "liquidation"
 ]
 # By default, we subscribe to these tables. They can be overridden
 # on websocket init via the "subscriptions" parameter.


### PR DESCRIPTION
Subscription via WS to liquidation doesn't take a symbol, adding it to the list of NO_SYMBOL_SUBS in utils

After this, the WS provides the data nicely:
![image](https://user-images.githubusercontent.com/10614716/103056817-f7592880-45d8-11eb-8b29-fbfdd2dc42dc.png)
